### PR TITLE
allow InternalIP selection for private network topologies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ git clone git@github.com:normanjoyner/kubectl-tmux-ssh.git ~/.kube/plugins/kubec
 tmux-ssh allows users to SSH into Kubernetes nodes by opening a new pane for each matching node
 
 Options:
+  -a, --address-type='ExternalIP': Node address type to query for (e.g. InternalIP/ExternalIP)
   -i, --identity-file='': Selects a file from which the identity (private key) for public key authentication is read
   -l, --selector='': Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
   -p, --ssh-port='': SSH port
@@ -37,4 +38,9 @@ kubectl plugin tmux-ssh
 SSH into master nodes only:
 ```
 kubectl plugin tmux-ssh -l node-role.kubernetes.io/master=""
+```
+
+SSH into master nodes in private network topologies:
+```
+kubectl plugin tmux-ssh -l "kubernetes.io/role=master" -a "InternalIP"
 ```

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -15,3 +15,7 @@ flags:
   - name: "ssh-username"
     shorthand: "u"
     desc: "SSH Username"
+  - name: "address-type"
+    shorthand: "a"
+    desc: "Node address type to query for (e.g. InternalIP/ExternalIP)"
+    defValue: "ExternalIP"

--- a/tmux-ssh
+++ b/tmux-ssh
@@ -5,6 +5,7 @@ SELECTOR=$KUBECTL_PLUGINS_LOCAL_FLAG_SELECTOR
 SSH_IDENTITY_FILE=$KUBECTL_PLUGINS_LOCAL_FLAG_IDENTITY_FILE
 SSH_USERNAME=$KUBECTL_PLUGINS_LOCAL_FLAG_SSH_USERNAME
 SSH_PORT=$KUBECTL_PLUGINS_LOCAL_FLAG_SSH_PORT
+ADDRESS_TYPE=$KUBECTL_PLUGINS_LOCAL_FLAG_ADDRESS_TYPE
 
 # creates a new tmux window
 createNewTmuxWindow() {
@@ -30,9 +31,9 @@ ensureTmuxSessionExists() {
 # gets node ips from a name selector
 getNodeIPs() {
     if [ -z "${SELECTOR}" ]; then
-        kubectl get nodes -o jsonpath="{.items[*].status.addresses[?(@.type=='ExternalIP')].address}"
+        kubectl get nodes -o jsonpath="{.items[*].status.addresses[?(@.type=='$ADDRESS_TYPE')].address}"
     else
-        kubectl get nodes -o jsonpath="{.items[*].status.addresses[?(@.type=='ExternalIP')].address}" -l ${SELECTOR}
+        kubectl get nodes -o jsonpath="{.items[*].status.addresses[?(@.type=='$ADDRESS_TYPE')].address}" -l ${SELECTOR}
     fi
 }
 
@@ -57,10 +58,13 @@ unsynchronizePanes() {
 }
 
 sshIntoNodes() {
-    INDEX=0
-
     IPS=$(getNodeIPs)
+    if [ -z "${IPS}" ]; then
+        echo "No matching nodes found!"
+        exit 1
+    fi
 
+    INDEX=0
     for IP in ${IPS}; do
         KUBECTL_SSH_COMMAND="ssh"
 
@@ -86,10 +90,6 @@ sshIntoNodes() {
         fi
         INDEX=$((INDEX+1))
     done
-
-    if [ ${INDEX} -eq 0 ]; then
-        echo "No matching nodes found!"
-    fi
 }
 
 # execute pre-command checks


### PR DESCRIPTION
Allows usage in private network topologies, like so:
`kubectl plugin tmux-ssh -l "kubernetes.io/role=master" -a "InternalIP"`